### PR TITLE
Fix assumption of linux platform in py-tensorflow

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -828,7 +828,7 @@ class PyTensorflow(Package, CudaPackage, ROCmPackage, PythonExtension):
     def post_configure_fixes(self):
         spec = self.spec
 
-        if spec.satisfies("@2.17:"):
+        if spec.satisfies("@2.17:") and ("patchelf" in spec):
             filter_file(
                 "patchelf",
                 spec["patchelf"].prefix.bin.patchelf,


### PR DESCRIPTION
post_configure_fixes assumed py-tensorflow depends on patchelf, but that dependency is platform dependent.